### PR TITLE
refactored navigation to remove old versions and clean up

### DIFF
--- a/part-header2nav.html
+++ b/part-header2nav.html
@@ -174,30 +174,34 @@
       <div class="sidebar"><a href="http://links.sonatype.com/products/nexus/pro/download" target="_blank">Repository Manager Pro <i class="fa fa-external-link"></i></a></div>
       <div class="sidebar"><a href="https://support.sonatype.com/entries/23756203" target="_blank">IQ Server <i class="fa fa-external-link"></i></a></div>
     </div>
-    <div class="sidebarTitle" id="nxDocsSectNxrm">Nexus Repository Manager</div>
+    <div class="sidebarTitle" id="nxDocsSectNxrm3">Nexus Repository Manager 3</div>
     <div class="sidebarSection">
-      <div class="sidebar"><a href="${toindex}nexus-book/index.html">Index</a></div>
-      <div class="sidebar">Version 3.0: <a href="${toindex}nexus-book/3.0/reference/index.html">HTML</a> | <a href="${toindex}nexus-book/3.0/pdf/nxbook-pdf.pdf">PDF</a></div>
+      <div class="sidebar"><a href="${toindex}nexus-book/index.html">Index & Archive</a></div>
+      <div class="sidebar"><a href="${toindex}nexus-book/3.0/reference/index.html">Documentation HTML</a></div>
+      <div class="sidebar"><a href="${toindex}nexus-book/3.0/pdf/nxbook-pdf.pdf">Documentation PDF</a></div>
+      <div class="sidebar"><a href="https://support.sonatype.com/hc/en-us/sections/203012688" target="_blank">Release Notes <i class="fa fa-external-link"></i></a></div>
+    </div>
+    <div class="sidebarTitle" id="nxDocsSectNxrm2">Nexus Repository Manager 2</div>
+    <div class="sidebarSection">
+      <div class="sidebar"><a href="${toindex}nexus-book/index.html">Index & Archive</a></div>
       <!-- links to latest/top level folder for HTML so that search is in context  -->
-      <div class="sidebar">Version 2.14: <a href="${toindex}nexus-book/reference/index.html">HTML</a> | <a href="${toindex}nexus-book/2.14/pdf/nxbook-pdf.pdf">PDF</a></div>
-      <div class="sidebar">Version 2.13: <a href="${toindex}nexus-book/2.13/reference/index.html">HTML</a> | <a href="${toindex}nexus-book/2.13/pdf/nxbook-pdf.pdf">PDF</a></div>
-      <div class="sidebar">Version 2.12: <a href="${toindex}nexus-book/2.12/reference/index.html">HTML</a> | <a href="${toindex}nexus-book/2.12/pdf/nxbook-pdf.pdf">PDF</a></div>
-      <div class="sidebar"><a href="http://links.sonatype.com/products/nexus/releasenotes">Release Notes <i class="fa fa-external-link"></i></a></div>
-      <div class="sidebar"><a href="http://www.sonatype.com/nexus/compare-repos">Compare Editions</a></div>
+      <div class="sidebar"><a href="${toindex}nexus-book/reference/index.html">Documentation HTML</a></div>
+      <div class="sidebar"><a href="${toindex}nexus-book/2.14/pdf/nxbook-pdf.pdf">Documentation PDF</a></div>
+      <div class="sidebar"><a href="http://links.sonatype.com/products/nexus/releasenotes" target="_blank">Release Notes <i class="fa fa-external-link"></i></a></div>
     </div>
     <div class="sidebarTitle" id="nxDocsSectIq">Nexus IQ Server</div>
     <div class="sidebarSection">
-      <div class="sidebar"><a href="${toindex}sonatype-clm-book/html/index.html">Index</a></div>
-      <div class="sidebar">Version 1.22: <a href="${toindex}sonatype-clm-book/html/book/index.html">HTML</a> | <a href="${toindex}sonatype-clm-book/1.22/pdf/book-clm.pdf">PDF</a></div>
-      <div class="sidebar">Version 1.21: <a href="${toindex}sonatype-clm-book/1.21/html/book/index.html">HTML</a> | <a href="${toindex}sonatype-clm-book/1.21/pdf/book-clm.pdf">PDF</a></div>
-      <div class="sidebar">Version 1.20: <a href="${toindex}sonatype-clm-book/1.20/html/book/index.html">HTML</a> | <a href="${toindex}sonatype-clm-book/1.20/pdf/book-clm.pdf">PDF</a></div>
-      <div class="sidebar"><a href="${toindex}sonatype-clm-book/html/release-notes/index.html">Release Notes</a></div>
+      <div class="sidebar"><a href="${toindex}sonatype-clm-book/html/index.html">Index & Archive</a></div>
+      <div class="sidebar"><a href="${toindex}sonatype-clm-book/html/book/index.html">Documentation HTML</a></div>
+      <div class="sidebar"><a href="${toindex}sonatype-clm-book/1.22/pdf/book-clm.pdf">Documentation PDF</a></div>
+      <div class="sidebar"><a href="${toindex}sonatype-clm-book/html/release-notes/index.html" target="_blank">Release Notes <i class="fa fa-external-link"></i></a></div>
     </div>
     <div class="sidebarTitle" id="nxDocsSectOther">Other Resources</div>
     <div class="sidebarSection">
      <div class="sidebar"><a href="http://support.sonatype.com/" target="_blank">Sonatype Support <i class="fa fa-external-link"></i></a></div>
      <div class="sidebar"><a href="http://www.sonatype.org/nexus/" target="_blank">Nexus Community <i class="fa fa-external-link"></i></a></div>
      <div class="sidebar"><a href="http://www.sonatype.com">Sonatype.com</a></div>
+     <div class="sidebar"><a href="https://www.sonatype.com/products-sonatype">Product Overview</a></div>
      <div class="sidebar"><a href="https://links.sonatype.com/products/nexus/community-chat" target="_blank">Live Chat <i class="fa fa-external-link"></i></a></div>
      <div class="sidebar"><a href="https://groups.google.com/a/glists.sonatype.com/forum/?hl=en#!forum/nexus-users" target="_blank">Mailinglist <i class="fa fa-external-link"></i></a></div>
     </div>


### PR DESCRIPTION
This is what it looks like. Each of the sections expand/contract as usual.

<img width="655" alt="screen shot 2016-09-28 at 08 43 51" src="https://cloud.githubusercontent.com/assets/145658/18921509/df18abc2-8559-11e6-8cd5-5491969be98f.png">
